### PR TITLE
Make filename pattern work with an array

### DIFF
--- a/lib/policial/style_guides/base.rb
+++ b/lib/policial/style_guides/base.rb
@@ -17,7 +17,7 @@ module Policial
         raise NotImplementedError, "must implement ##{__method__}"
       end
 
-      def filename_pattern
+      def filename_patterns
         raise NotImplementedError, "must implement ##{__method__}"
       end
 
@@ -44,7 +44,9 @@ module Policial
       end
 
       def matches_pattern?(filename)
-        !(filename =~ filename_pattern).nil?
+        filename_patterns.any? do |filename_pattern|
+          !(filename =~ filename_pattern).nil?
+        end
       end
     end
   end

--- a/lib/policial/style_guides/coffeescript.rb
+++ b/lib/policial/style_guides/coffeescript.rb
@@ -17,8 +17,8 @@ module Policial
         false
       end
 
-      def filename_pattern
-        /.+\.coffee\z/
+      def filename_patterns
+        [/.+\.coffee\z/]
       end
 
       def default_config_file

--- a/lib/policial/style_guides/javascript.rb
+++ b/lib/policial/style_guides/javascript.rb
@@ -17,8 +17,8 @@ module Policial
         false
       end
 
-      def filename_pattern
-        /.+\.js\z/
+      def filename_patterns
+        [/.+\.js\z/]
       end
 
       def default_config_file

--- a/lib/policial/style_guides/ruby.rb
+++ b/lib/policial/style_guides/ruby.rb
@@ -20,8 +20,8 @@ module Policial
         config.file_to_exclude?(filename)
       end
 
-      def filename_pattern
-        /.+\.rb\z/
+      def filename_patterns
+        [/.+\.rb\z/]
       end
 
       def default_config_file

--- a/lib/policial/style_guides/ruby.rb
+++ b/lib/policial/style_guides/ruby.rb
@@ -21,7 +21,9 @@ module Policial
       end
 
       def filename_patterns
-        [/.+\.rb\z/]
+        all_cop_includes = config['AllCops']['Include'] || []
+        all_cop_includes = all_cop_includes.map { |a| /#{Regexp.quote(a)}/ }
+        ([/.+\.rb\z/] + all_cop_includes).flatten
       end
 
       def default_config_file

--- a/lib/policial/style_guides/scss.rb
+++ b/lib/policial/style_guides/scss.rb
@@ -22,8 +22,8 @@ module Policial
         config.excluded_file?(File.expand_path(filename))
       end
 
-      def filename_pattern
-        /.+\.scss\z/
+      def filename_patterns
+        [/.+\.scss\z/]
       end
 
       def default_config_file

--- a/spec/style_guides/base_spec.rb
+++ b/spec/style_guides/base_spec.rb
@@ -17,9 +17,9 @@ describe Policial::StyleGuides::Base do
 
   describe '#filename_pattern' do
     it 'raises NotImplementedError' do
-      expect { subject.filename_pattern }
+      expect { subject.filename_patterns }
         .to raise_error(
-          NotImplementedError, 'must implement #filename_pattern'
+          NotImplementedError, 'must implement #filename_patterns'
         )
     end
   end
@@ -81,7 +81,7 @@ describe Policial::StyleGuides::Base do
   describe '#investigate?' do
     context 'when style guide is enabled and filename matches pattern' do
       before do
-        allow(subject).to receive(:filename_pattern).and_return(/.*\.erb/)
+        allow(subject).to receive(:filename_patterns).and_return([/.*\.erb/])
       end
 
       context 'when filename is not excluded' do
@@ -115,7 +115,7 @@ describe Policial::StyleGuides::Base do
 
       context 'when filename does not match pattern' do
         before do
-          allow(subject).to receive(:filename_pattern).and_return(/.*\.js/)
+          allow(subject).to receive(:filename_patterns).and_return([/.*\.js/])
         end
 
         it 'is false' do
@@ -126,7 +126,7 @@ describe Policial::StyleGuides::Base do
 
     context 'when filename matches pattern and it is not excluded' do
       before do
-        allow(subject).to receive(:filename_pattern).and_return(/.*\.erb/)
+        allow(subject).to receive(:filename_patterns).and_return([/.*\.erb/])
         allow(subject).to receive(
           :exclude_file?).with('app/view.erb').and_return(false)
       end

--- a/spec/style_guides/coffeescript_spec.rb
+++ b/spec/style_guides/coffeescript_spec.rb
@@ -86,11 +86,11 @@ describe Policial::StyleGuides::CoffeeScript do
     end
   end
 
-  describe '#filename_pattern' do
+  describe '#filename_patterns' do
     it 'matches CoffeeScript files' do
-      expect(subject.filename_pattern).to match('my_file.coffee')
-      expect(subject.filename_pattern).to match('app/script.coffee')
-      expect(subject.filename_pattern).not_to match('my_file.coffee.erb')
+      expect(subject.filename_patterns.first).to match('my_file.coffee')
+      expect(subject.filename_patterns.first).to match('app/script.coffee')
+      expect(subject.filename_patterns.first).not_to match('my_file.coffee.erb')
     end
   end
 

--- a/spec/style_guides/javascript_spec.rb
+++ b/spec/style_guides/javascript_spec.rb
@@ -56,7 +56,7 @@ describe Policial::StyleGuides::JavaScript do
     context 'with custom configuration' do
       let(:custom_config) do
         {
-          'rules': {
+          'rules' => {
             'no-plusplus' => 2
           }
         }

--- a/spec/style_guides/javascript_spec.rb
+++ b/spec/style_guides/javascript_spec.rb
@@ -77,12 +77,12 @@ describe Policial::StyleGuides::JavaScript do
     end
   end
 
-  describe '#filename_pattern' do
+  describe '#filename_patterns' do
     it 'matches Javascript files' do
-      expect(subject.filename_pattern).to match('my_file.js')
-      expect(subject.filename_pattern).to match('app/script.js')
-      expect(subject.filename_pattern).not_to match('my_file.js.erb')
-      expect(subject.filename_pattern).not_to match('my_file.coffee')
+      expect(subject.filename_patterns.first).to match('my_file.js')
+      expect(subject.filename_patterns.first).to match('app/script.js')
+      expect(subject.filename_patterns.first).not_to match('my_file.js.erb')
+      expect(subject.filename_patterns.first).not_to match('my_file.coffee')
     end
   end
 

--- a/spec/style_guides/ruby_spec.rb
+++ b/spec/style_guides/ruby_spec.rb
@@ -207,10 +207,30 @@ describe Policial::StyleGuides::Ruby do
   end
 
   describe '#filename_patterns' do
-    it 'matches Ruby files' do
-      expect(subject.filename_patterns.first).to match('my_file.rb')
-      expect(subject.filename_patterns.first).to match('app/base.rb')
-      expect(subject.filename_patterns.first).not_to match('my_file.erb')
+    context 'when custom config has Include' do
+      let(:custom_config) do
+        { 'AllCops' => { 'Include' => ['fastlane/Fastfile'] } }
+      end
+
+      it 'includes AllCops Include in filename_patterns' do
+        patterns = [/.+\.rb\z/, %r{fastlane/Fastfile}]
+        expect(subject.filename_patterns).to match(patterns)
+      end
+
+      it 'matches Ruby files' do
+        expect(subject.filename_patterns.first).to match('my_file.rb')
+        expect(subject.filename_patterns.first).to match('app/base.rb')
+        expect(subject.filename_patterns.first).not_to match('my_file.erb')
+        expect(subject.filename_patterns.last).to match('fastlane/Fastfile')
+      end
+    end
+
+    context 'when custom config is nil' do
+      it 'matches Ruby files' do
+        expect(subject.filename_patterns.first).to match('my_file.rb')
+        expect(subject.filename_patterns.first).to match('app/base.rb')
+        expect(subject.filename_patterns.first).not_to match('my_file.erb')
+      end
     end
   end
 

--- a/spec/style_guides/ruby_spec.rb
+++ b/spec/style_guides/ruby_spec.rb
@@ -206,11 +206,11 @@ describe Policial::StyleGuides::Ruby do
     end
   end
 
-  describe '#filename_pattern' do
+  describe '#filename_patterns' do
     it 'matches Ruby files' do
-      expect(subject.filename_pattern).to match('my_file.rb')
-      expect(subject.filename_pattern).to match('app/base.rb')
-      expect(subject.filename_pattern).not_to match('my_file.erb')
+      expect(subject.filename_patterns.first).to match('my_file.rb')
+      expect(subject.filename_patterns.first).to match('app/base.rb')
+      expect(subject.filename_patterns.first).not_to match('my_file.erb')
     end
   end
 

--- a/spec/style_guides/scss_spec.rb
+++ b/spec/style_guides/scss_spec.rb
@@ -136,12 +136,12 @@ describe Policial::StyleGuides::Scss do
     end
   end
 
-  describe '#filename_pattern' do
+  describe '#filename_patterns' do
     it 'matches SCSS files' do
-      expect(subject.filename_pattern).to match('my_file.scss')
-      expect(subject.filename_pattern).to match('app/base.scss')
-      expect(subject.filename_pattern).not_to match('my_file.css')
-      expect(subject.filename_pattern).not_to match('my_file.scss.erb')
+      expect(subject.filename_patterns.first).to match('my_file.scss')
+      expect(subject.filename_patterns.first).to match('app/base.scss')
+      expect(subject.filename_patterns.first).not_to match('my_file.css')
+      expect(subject.filename_patterns.first).not_to match('my_file.scss.erb')
     end
   end
 


### PR DESCRIPTION
- As the title says, simply update to make things work with an array of filename_patterns.
- Take into account Rubocop AllCop/Include in filename_patterns in Ruby land.

cc @volmer 
