### PR TITLE
Fix coffee lint link

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ your repo. Please see [RuboCop's README](https://github.com/bbatsov/rubocop).
 
 You can setup your CoffeeScript code style rules with a `coffeelint.json`
 file in your repo. For more information on how customize the linter rules please
-visit the [Coffeelint website](https://coffelint.org).
+visit the [Coffeelint website](http://coffeelint.org).
 
 ## SCSS
 


### PR DESCRIPTION
# Problem

The url of the coffelint website from the README is wrong.

![coffelint org 2016-11-01 21-05-45](https://cloud.githubusercontent.com/assets/6765108/19913276/86580eb8-a077-11e6-8466-f5a6797edbd5.png)

# Solution

- Fix it with the right link for [coffeelint.org](http://coffeelint.org)

@volmer 