### PR TITLE
Line range support

### DIFF
--- a/lib/policial/linters/coffeescript.rb
+++ b/lib/policial/linters/coffeescript.rb
@@ -30,7 +30,10 @@ module Policial
       def violations(file, errors)
         errors.map do |error|
           Violation.new(
-            file, Range.new(error['lineNumber'], error['lineNumber']), error['message'], error['rule']
+            file,
+            Range.new(error['lineNumber'], error['lineNumber']),
+            error['message'],
+            error['rule']
           )
         end
       end

--- a/lib/policial/linters/coffeescript.rb
+++ b/lib/policial/linters/coffeescript.rb
@@ -30,7 +30,7 @@ module Policial
       def violations(file, errors)
         errors.map do |error|
           Violation.new(
-            file, error['lineNumber'], error['message'], error['rule']
+            file, Range.new(error['lineNumber'], error['lineNumber']), error['message'], error['rule']
           )
         end
       end

--- a/lib/policial/linters/javascript.rb
+++ b/lib/policial/linters/javascript.rb
@@ -39,7 +39,7 @@ module Policial
 
           Violation.new(
             file,
-            error['line'],
+            Range.new(error['line'], error['line']),
             error['message'],
             error['ruleId'] || 'undefined'
           )

--- a/lib/policial/linters/ruby.rb
+++ b/lib/policial/linters/ruby.rb
@@ -13,7 +13,10 @@ module Policial
 
         offenses.reject(&:disabled?).map do |offense|
           Violation.new(
-            file, offense.line, offense.message.strip, offense.cop_name
+            file,
+            Range.new(offense.location.first_line, offense.location.last_line),
+            offense.message.strip,
+            offense.cop_name
           )
         end
       end

--- a/lib/policial/linters/scss.rb
+++ b/lib/policial/linters/scss.rb
@@ -48,7 +48,10 @@ module Policial
         runner.lints.map do |lint|
           linter_name = lint.linter&.name || 'undefined'
           Violation.new(
-            file, Range.new(lint.location.line, lint.location.line), lint.description, linter_name
+            file,
+            Range.new(lint.location.line, lint.location.line),
+            lint.description,
+            linter_name
           )
         end
       end

--- a/lib/policial/linters/scss.rb
+++ b/lib/policial/linters/scss.rb
@@ -48,7 +48,7 @@ module Policial
         runner.lints.map do |lint|
           linter_name = lint.linter&.name || 'undefined'
           Violation.new(
-            file, lint.location.line, lint.description, linter_name
+            file, Range.new(lint.location.line, lint.location.line), lint.description, linter_name
           )
         end
       end

--- a/lib/policial/violation.rb
+++ b/lib/policial/violation.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module Policial
-  # Public: Hold file, line, and message. Built by linters.
+  # Public: Hold file, line range, and message. Built by linters.
   class Violation
-    attr_reader :line_number, :message, :linter
+    attr_reader :line_range, :message, :linter
 
-    def initialize(file, line_number, message, linter)
+    def initialize(file, line_range, message, linter)
       @file        = file
-      @line_number = line_number
+      @line_range  = line_range
       @message     = message
       @linter      = linter
     end
@@ -16,16 +16,12 @@ module Policial
       @file.filename
     end
 
-    def line
-      @line ||= @file.line_at(line_number)
-    end
-
-    def patch_position
-      line.patch_position
+    def lines
+      @lines ||= @line_range.map { |line_number| @file.line_at(line_number) }
     end
 
     def on_changed_line?
-      line.changed?
+      lines.any? { |line| line.changed? }
     end
   end
 end

--- a/lib/policial/violation.rb
+++ b/lib/policial/violation.rb
@@ -21,7 +21,7 @@ module Policial
     end
 
     def on_changed_line?
-      lines.any? { |line| line.changed? }
+      lines.any?(&:changed?)
     end
   end
 end

--- a/spec/linters/coffeescript_spec.rb
+++ b/spec/linters/coffeescript_spec.rb
@@ -36,13 +36,13 @@ describe Policial::Linters::CoffeeScript do
       expect(violations.count).to eq(2)
 
       expect(violations[0].filename).to eq('test.coffee')
-      expect(violations[0].line_number).to eq(1)
+      expect(violations[0].line_range).to eq(1..1)
       expect(violations[0].message).to eq(
         'Unnecessary fat arrow'
       )
 
       expect(violations[1].filename).to eq('test.coffee')
-      expect(violations[1].line_number).to eq(3)
+      expect(violations[1].line_range).to eq(3..3)
       expect(violations[1].message).to eq(
         'Class name should be UpperCamelCased'
       )

--- a/spec/linters/javascript_spec.rb
+++ b/spec/linters/javascript_spec.rb
@@ -32,7 +32,7 @@ describe Policial::Linters::JavaScript do
 
       expect(violations.count).to eq(1)
       expect(violations[0].filename).to eq('test.js')
-      expect(violations[0].line_number).to eq(1)
+      expect(violations[0].line_range).to eq(1..1)
       expect(violations[0].linter).to eq('strict')
       expect(violations[0].message).to eq(
         "Use the function form of 'use strict'."
@@ -45,7 +45,7 @@ describe Policial::Linters::JavaScript do
 
       expect(violations.count).to eq(1)
       expect(violations.first.filename).to eq('test.js')
-      expect(violations.first.line_number).to eq(1)
+      expect(violations.first.line_range).to eq(1..1)
       expect(violations.first.linter).to eq('undefined')
       expect(violations.first.message).to eq(
         "Parsing error: The keyword 'import' is reserved"

--- a/spec/linters/ruby_spec.rb
+++ b/spec/linters/ruby_spec.rb
@@ -29,11 +29,30 @@ describe Policial::Linters::Ruby do
 
       expect(violations.count).to eq(1)
       expect(violations.first.filename).to eq('test.rb')
-      expect(violations.first.line_number).to eq(3)
+      expect(violations.first.line_range).to eq(3..3)
       expect(violations.first.linter).to eq('Style/StringLiterals')
       expect(violations.first.message).to eq(
         "Style/StringLiterals: Prefer single-quoted strings when you don't "\
         'need string interpolation or special symbols.'
+      )
+    end
+
+    it 'detects violations spanning multiple lines' do
+      file_content = [
+        '<<~BLOCK',
+        '  foo',
+        ' bar',
+        'BLOCK'
+      ]
+      file = build_file('test.rb', file_content)
+
+      violations = subject.violations_in_file(file)
+
+      expect(violations.count).to eq(1)
+      expect(violations[0].line_range).to eq(4..6)
+      expect(violations[0].linter).to eq('Layout/IndentHeredoc')
+      expect(violations[0].message).to eq(
+        'Layout/IndentHeredoc: Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<~`.'
       )
     end
 
@@ -47,21 +66,21 @@ describe Policial::Linters::Ruby do
       expect(violations.count).to eq(3)
 
       expect(violations[0].filename).to eq('test.rb')
-      expect(violations[0].line_number).to eq(3)
+      expect(violations[0].line_range).to eq(3..3)
       expect(violations[0].linter).to eq('Layout/SpaceInsideHashLiteralBraces')
       expect(violations[0].message).to eq(
         'Layout/SpaceInsideHashLiteralBraces: Space inside { missing.'
       )
 
       expect(violations[1].filename).to eq('test.rb')
-      expect(violations[1].line_number).to eq(3)
+      expect(violations[1].line_range).to eq(3..3)
       expect(violations[1].linter).to eq('Lint/Void')
       expect(violations[1].message).to eq(
         'Lint/Void: Literal `{first_line: :violates }` used in void context.'
       )
 
       expect(violations[2].filename).to eq('test.rb')
-      expect(violations[2].line_number).to eq(4)
+      expect(violations[2].line_range).to eq(4..4)
       expect(violations[2].linter).to eq('Style/StringLiterals')
       expect(violations[2].message).to eq(
         "Style/StringLiterals: Prefer single-quoted strings when you don't "\
@@ -82,7 +101,7 @@ describe Policial::Linters::Ruby do
 
         expect(violations.count).to eq(1)
         expect(violations.first.filename).to eq('test.rb')
-        expect(violations.first.line_number).to eq(3)
+        expect(violations.first.line_range).to eq(3..3)
         expect(violations.first.linter).to eq('Style/StringLiterals')
         expect(violations.first.message).to eq(
           'Style/StringLiterals: Prefer double-quoted strings unless you need '\

--- a/spec/linters/ruby_spec.rb
+++ b/spec/linters/ruby_spec.rb
@@ -52,7 +52,8 @@ describe Policial::Linters::Ruby do
       expect(violations[0].line_range).to eq(4..6)
       expect(violations[0].linter).to eq('Layout/IndentHeredoc')
       expect(violations[0].message).to eq(
-        'Layout/IndentHeredoc: Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<~`.'
+        'Layout/IndentHeredoc: Use 2 spaces for indentation in a '\
+        'heredoc by using `<<~` instead of `<<~`.'
       )
     end
 

--- a/spec/linters/scss_spec.rb
+++ b/spec/linters/scss_spec.rb
@@ -29,7 +29,7 @@ describe Policial::Linters::Scss do
 
       expect(violations.count).to eq(1)
       expect(violations.first.filename).to eq('test.scss')
-      expect(violations.first.line_number).to eq(1)
+      expect(violations.first.line_range).to eq(1..1)
       expect(violations.first.linter).to eq('BorderZero')
       expect(violations.first.message).to eq(
         '`border: 0` is preferred over `border: none`'
@@ -42,7 +42,7 @@ describe Policial::Linters::Scss do
 
       expect(violations.count).to eq(1)
       expect(violations.first.filename).to eq('test.scss')
-      expect(violations.first.line_number).to eq(2)
+      expect(violations.first.line_range).to eq(2..2)
       expect(violations.first.linter).to eq('Syntax')
       expect(violations.first.message).to eq(
         'Syntax Error: Invalid CSS after "p { border:": '\
@@ -63,21 +63,21 @@ describe Policial::Linters::Scss do
       expect(violations.count).to eq(3)
 
       expect(violations[0].filename).to eq('test.scss')
-      expect(violations[0].line_number).to eq(1)
+      expect(violations[0].line_range).to eq(1..1)
       expect(violations[0].linter).to eq('BorderZero')
       expect(violations[0].message).to eq(
         '`border: 0` is preferred over `border: none`'
       )
 
       expect(violations[1].filename).to eq('test.scss')
-      expect(violations[1].line_number).to eq(2)
+      expect(violations[1].line_range).to eq(2..2)
       expect(violations[1].linter).to eq('BorderZero')
       expect(violations[1].message).to eq(
         '`border: 0` is preferred over `border: none`'
       )
 
       expect(violations[2].filename).to eq('test.scss')
-      expect(violations[2].line_number).to eq(2)
+      expect(violations[2].line_range).to eq(2..2)
       expect(violations[2].linter).to eq('StringQuotes')
       expect(violations[2].message).to eq('Prefer single quoted strings')
     end
@@ -89,7 +89,7 @@ describe Policial::Linters::Scss do
 
       expect(first_run.count).to eq second_run.count
       expect(first_run.first.filename).to eq second_run.first.filename
-      expect(first_run.first.line_number).to eq second_run.first.line_number
+      expect(first_run.first.line_range).to eq second_run.first.line_range
       expect(first_run.first.linter).to eq second_run.first.linter
       expect(first_run.first.message).to eq second_run.first.message
     end
@@ -109,7 +109,7 @@ describe Policial::Linters::Scss do
 
         expect(violations.count).to eq(1)
         expect(violations.first.filename).to eq('test.scss')
-        expect(violations.first.line_number).to eq(1)
+        expect(violations.first.line_range).to eq(1..1)
         expect(violations.first.linter).to eq('StringQuotes')
         expect(violations.first.message).to eq('Prefer double-quoted strings')
       end

--- a/spec/violation_spec.rb
+++ b/spec/violation_spec.rb
@@ -1,3 +1,79 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+
+describe Policial::Violation do
+  let(:file_content) { [double('line', content: 'do_something', changed?: true)] }
+  let(:file) { build_file('application.rb', *file_content) }
+  let(:line_range) { 1..1 }
+  let(:message) { 'There is an error.' }
+  let(:linter_name) { 'Style/ErrorDetector' }
+  subject { described_class.new(file, line_range, message, linter_name) }
+
+  describe '#filename' do
+    it { expect(subject.filename).to eq 'application.rb' }
+  end
+
+  describe '#line_range' do
+    let(:line_range) { 5..14 }
+    it { expect(subject.line_range).to eq 5..14 }
+  end
+
+  describe '#message' do
+    it { expect(subject.message).to eq 'There is an error.' }
+  end
+
+  describe '#linter' do
+    it { expect(subject.linter).to eq 'Style/ErrorDetector' }
+  end
+
+  describe '#lines' do
+    let(:file_content) do
+      [
+        double('line', content: 'if something?', changed?: false),
+        double('line', content: '  say_hello', changed?: false),
+        double('line', content: '  return true', changed?: false),
+        double('line', content: 'end', changed?: false),
+      ]
+    end
+    let(:line_range) { 1..2 }
+    it { expect(subject.lines).to eq file_content[1..2] }
+    it { expect(subject.lines.map(&:content)).to eq ['  say_hello', '  return true'] }
+  end
+
+  describe '#on_changed_line?' do
+    context 'when at least one line in line_range has been changed' do
+      let(:file_content) do
+        [
+          double('line', content: 'if something?', changed?: false),
+          double('line', content: '  say_hello', changed?: false),
+          double('line', content: '  return true', changed?: true),
+          double('line', content: 'end', changed?: false),
+        ]
+      end
+      let(:line_range) { 1..3 }
+      it { expect(subject.on_changed_line?).to eq true }
+    end
+
+    context 'when no line in line_range has been changed' do
+      let(:file_content) do
+        [
+          double('line', content: 'if something?', changed?: false),
+          double('line', content: '  say_hello', changed?: false),
+          double('line', content: '  return true', changed?: false),
+          double('line', content: 'end', changed?: false),
+        ]
+      end
+      let(:line_range) { 1..3 }
+      it { expect(subject.on_changed_line?).to eq false }
+    end
+  end
+
+  private
+
+  def build_file(name, *lines)
+    file = double('file', filename: name, content: lines.map(&:content).join("\n") + "\n")
+    allow(file).to receive(:line_at) { |n| lines[n] }
+    file
+  end
+end


### PR DESCRIPTION
Change `Violation`'s line_number for a line_range. The issue here is, for a violation spanning multiple lines, trying to detect if a changed line intersects the violation's location is inaccurate. Some lines in the changeset may be part of the violation but not on the first line.

Consider the diff:
```ruby
 <<~HEREDOC
   foo
+ bar
 HEREDOC
```

The first line (`foo`)  is indented correctly, but the new line (`bar`)  is not. Before this PR, the `line_number` for this violation would match the first line (`<<~HEREDOC`) even though the changed line is the 3rd. This means `Violation#on_changed_line?` returns false, causing `StyleChecker` to reject the violation as if it wasn't part of the patch.

@volmer 
