### PR TITLE
Resolve local file inheritance to a repo specific URL

### DIFF
--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -23,6 +23,14 @@ module GitHubApiHelper
     stub_contents_request(repo, sha, file, body)
   end
 
+  def stub_contents_request_with_download_url(repo, sha:, file:, download_url:)
+    body = JSON.generate(
+      download_url: download_url
+    )
+
+    stub_contents_request(repo, sha, file, body)
+  end
+
   def stub_contents_request_with_fixture(repo, sha:, file:, fixture:)
     body = File.read("spec/support/fixtures/#{fixture}")
 


### PR DESCRIPTION
## What

Convert references to local files in `inherit_from` in the provided
`rubocop.yml` with URL's to those files on Github at the commit pointed to by
the commit being investigated by Policial.

## Why

Rubocop provides a method in its config files to be able to inherit from other
Rubocop configs. This is generally used for a couple of concrete cases.

* Providing a URL for a base config that Rubocop will download and merge with
  the configuration file passed in the `--config` option (or `.rubocop.yml` if
  nothing is passed).
* Providing a local base file that will be loaded and merged with the provided
  configuration file.

Policial implicitly supported the former approach because Rubocop was handling
the URL downloading. However the latter approach of passing a relative file
path is problematic. This is because when Policial's Rubocop linter parses the
custom Rubocop config for the repository, it first downloads the config file
from the remote repository and then stores it in a `Tempfile` on the local disk

It then passes that tempfile to the `RuboCop::ConfigLoader` to configure
Rubocop. From this point on Rubocop's config parser takes over. And as it's
been handed a local file on disk, it then attempts to resolve any file paths it
can see as being relative to the path of the Tempfile.

## How

Policial has historically handled this by parsing the custom config after it
has fetched it from the remote repository and before it writes the Tempfile,
and removing all references to local files from the `inherit_from` stanza.

This commit allows Policial to load the config from local files defined in a
projects `inherit_from` stanza by using the `Commit` object to ask the Github
API what the download url for that particular file is. And then replacing the
entry in the `inherit_from` stanza with a URL to the file on Github.

This works because of two reasons:

* Octokit and the V3 Github API allows us to request the download_url of any
  file in a repo, at a specific commit using the [Contents API]
* Rubocop will automatically download and merge any configuration file provided
  as a URL in the `inherits_from` stanza which is [documented here]

[Contents API]:https://developer.github.com/v3/repos/contents/
[documented here]: https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#inheriting-configuration-from-a-remote-url
